### PR TITLE
Fix time parsing for vacation rows

### DIFF
--- a/content.js
+++ b/content.js
@@ -120,6 +120,13 @@ setTimeout(async () => {
         const now = new Date();
         return new Date(now.getFullYear(), now.getMonth(), now.getDate(), ...parts);
       }
+
+      // Convertit une chaîne "HH:MM" en nombre d'heures décimal
+      parseTimeStringToHours(timeString) {
+        if (!timeString || timeString === '-') return 0;
+        const [hours, minutes] = timeString.split(':').map(Number);
+        return hours + (minutes || 0) / 60;
+      }
   
       formatHoursToTimeString(hours) {
         const totalMinutes = Math.round(hours * 60);


### PR DESCRIPTION
## Notes
- `npm test` échoue car aucun `package.json` n'est présent dans ce dépôt.

## Summary
- add `parseTimeStringToHours` utility to convert strings like `HH:MM` into decimal hours



------
https://chatgpt.com/codex/tasks/task_e_6846c0d29fdc83208d7aed8585f53108