### PR TITLE
Improve popup clarity

### DIFF
--- a/popup.css
+++ b/popup.css
@@ -7,7 +7,7 @@
 
 body {
     font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+    background: linear-gradient(135deg, #fff35e 0%, #ffd600 100%);
     color: #333;
     line-height: 1.6;
 }
@@ -34,7 +34,7 @@ body {
 }
 
 .header {
-    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+    background: linear-gradient(135deg, #fff35e 0%, #ffd600 100%);
     color: white;
     padding: 20px;
     text-align: center;
@@ -57,6 +57,12 @@ body {
 .subtitle {
     opacity: 0.9;
     font-size: 14px;
+}
+
+.description {
+    font-size: 13px;
+    opacity: 0.85;
+    margin-top: 4px;
 }
 
 .content {
@@ -83,7 +89,7 @@ body {
     padding: 20px;
     background: #f8f9fa;
     border-radius: 8px;
-    border-left: 4px solid #667eea;
+    border-left: 4px solid #ffd600;
 }
 
 .config-section h2 {
@@ -129,8 +135,8 @@ input, select, textarea {
 
 input:focus, select:focus, textarea:focus {
     outline: none;
-    border-color: #667eea;
-    box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.1);
+    border-color: #ffd600;
+    box-shadow: 0 0 0 3px rgba(255, 214, 0, 0.2);
 }
 
 textarea {
@@ -174,13 +180,13 @@ textarea {
 }
 
 .btn-primary {
-    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-    color: white;
+    background: linear-gradient(135deg, #fff35e 0%, #ffd600 100%);
+    color: #333;
 }
 
 .btn-primary:hover {
     transform: translateY(-1px);
-    box-shadow: 0 4px 12px rgba(102, 126, 234, 0.3);
+    box-shadow: 0 4px 12px rgba(255, 214, 0, 0.4);
 }
 
 .btn-secondary {
@@ -191,6 +197,12 @@ textarea {
 .btn-secondary:hover {
     background: #5a6268;
     transform: translateY(-1px);
+}
+
+/* Highlight select when language changed */
+.lang-changed {
+    border-color: #28a745 !important;
+    box-shadow: 0 0 0 3px rgba(40, 167, 69, 0.2) !important;
 }
 
 .btn:active {

--- a/popup.html
+++ b/popup.html
@@ -12,6 +12,7 @@
             <img src="clock.png" alt="Clock" class="logo">
             <h1>Time Manager</h1>
             <p class="subtitle">Configuration</p>
+            <p class="description">Personnalisez les paramètres ci-dessous. Les modifications sont sauvegardées automatiquement. Changez la langue pour traduire l'interface puis redémarrez la page.</p>
         </header>
 
         <main class="content">

--- a/popup.js
+++ b/popup.js
@@ -13,7 +13,9 @@ class TimeManagerPopup {
                 MINIMUM_DURATION_MINUTES: 30
             }
         };
-        
+
+        this.translations = window.TRANSLATIONS['fr'];
+
         this.init();
     }
 
@@ -27,6 +29,8 @@ class TimeManagerPopup {
             .addEventListener('click', () => this.saveConfiguration());
         document.getElementById('resetBtn')
             .addEventListener('click', () => this.resetConfiguration());
+        document.getElementById('language')
+            .addEventListener('change', (e) => this.onLanguageChange(e));
         this.setupAutoSave();
     }
 
@@ -43,6 +47,13 @@ class TimeManagerPopup {
         });
     }
 
+    onLanguageChange(event) {
+        const select = event.target;
+        this.translations = window.TRANSLATIONS[select.value] || this.translations;
+        select.classList.add('lang-changed');
+        setTimeout(() => select.classList.remove('lang-changed'), 1200);
+    }
+
     loadConfiguration() {
         chrome.storage.sync.get(['timeManagerConfig'], (result) => {
             if (chrome.runtime.lastError) {
@@ -52,7 +63,9 @@ class TimeManagerPopup {
             } else {
                 const cfg = result.timeManagerConfig || this.defaultConfig;
                 this.populateForm(cfg);
-                this.showStatus('⚙️ Configuration chargée', 'info');
+                this.translations = window.TRANSLATIONS[cfg.LANGUAGE] || this.translations;
+                const loadedMsg = this.translations.configLoaded || 'Configuration chargée';
+                this.showStatus(`⚙️ ${loadedMsg}`, 'info');
             }
         });
     }
@@ -81,7 +94,10 @@ class TimeManagerPopup {
                 console.error(chrome.runtime.lastError);
                 this.showStatus('❌ Erreur de sauvegarde', 'error');
             } else {
-                this.showStatus('✅ Configuration sauvegardée !', 'success');
+                this.translations = window.TRANSLATIONS[config.LANGUAGE] || this.translations;
+                const msg = this.translations.restartNotice || '';
+                const saved = this.translations.configSaved || 'Configuration sauvegardée !';
+                this.showStatus(`✅ ${saved} ${msg}`, 'success');
                 this.reloadActiveTab();
             }
         });
@@ -132,7 +148,9 @@ class TimeManagerPopup {
                 this.showStatus('❌ Erreur de réinitialisation', 'error');
             } else {
                 this.populateForm(this.defaultConfig);
-                this.showStatus('🔄 Configuration réinitialisée', 'info');
+                this.translations = window.TRANSLATIONS[this.defaultConfig.LANGUAGE] || this.translations;
+                const resetMsg = this.translations.configReset || 'Configuration réinitialisée';
+                this.showStatus(`🔄 ${resetMsg}`, 'info');
             }
         });
     }

--- a/translations.js
+++ b/translations.js
@@ -12,7 +12,11 @@ window.TRANSLATIONS = {
         overtimeThisWeek: "Heures supplémentaires cette semaine",
         none: "Aucun",
         yes: "Oui",
-        no: "Non"
+        no: "Non",
+        restartNotice: "Veuillez recharger l'onglet pour appliquer la nouvelle langue",
+        configSaved: "Configuration sauvegardée !",
+        configLoaded: "Configuration chargée",
+        configReset: "Configuration réinitialisée"
     },
     en: {
         welcome: "Welcome",
@@ -26,7 +30,11 @@ window.TRANSLATIONS = {
         overtimeThisWeek: "Overtime This Week",
         none: "None",
         yes: "Yes",
-        no: "No"
+        no: "No",
+        restartNotice: "Please reload the tab to apply the new language",
+        configSaved: "Configuration saved!",
+        configLoaded: "Configuration loaded",
+        configReset: "Configuration reset"
     },
     de: {
         welcome: "Willkommen",
@@ -40,6 +48,10 @@ window.TRANSLATIONS = {
         overtimeThisWeek: "Überstunden diese Woche",
         none: "Keine",
         yes: "Ja",
-        no: "Nein"
+        no: "Nein",
+        restartNotice: "Laden Sie den Tab neu, um die neue Sprache anzuwenden",
+        configSaved: "Konfiguration gespeichert!",
+        configLoaded: "Konfiguration geladen",
+        configReset: "Konfiguration zurückgesetzt"
     }
 };


### PR DESCRIPTION
## Summary
- lighten color scheme for popup header, body and primary button
- add short description text in the popup header to clarify automatic saving
- highlight language selector and show message requiring page reload after saving
- extend translations for new messages

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6846c5d580248320a5545c7db69dbf16