### PR TITLE
Improve popup translations

### DIFF
--- a/popup.html
+++ b/popup.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Time Manager - Configuration</title>
+    <title data-i18n="popup.title">Time Manager - Configuration</title>
     <link rel="stylesheet" href="popup.css">
 </head>
 <body>
@@ -11,20 +11,20 @@
         <header class="header">
             <img src="clock.png" alt="Clock" class="logo">
             <h1>Time Manager</h1>
-            <p class="subtitle">Configuration</p>
-            <p class="description">Personnalisez les paramètres ci-dessous. Les modifications sont sauvegardées automatiquement. Changez la langue pour traduire l'interface puis redémarrez la page.</p>
+            <p class="subtitle" data-i18n="popup.subtitle">Configuration</p>
+            <p class="description" data-i18n="popup.description">Personnalisez les paramètres ci-dessous. Les modifications sont sauvegardées automatiquement. Changez la langue pour traduire l'interface puis redémarrez la page.</p>
         </header>
 
         <main class="content">
             <section class="config-section">
-                <h2>⏰ Heures de travail</h2>
+                <h2 data-i18n="popup.workHoursTitle">⏰ Heures de travail</h2>
                 <div class="form-group">
-                    <label for="dailyHours">Heures par jour:</label>
+                    <label for="dailyHours" data-i18n="popup.dailyHoursLabel">Heures par jour:</label>
                     <input type="number" id="dailyHours" step="0.1" min="1" max="12" placeholder="8.4">
                     <span class="help-text">Exemple: 8h24 = 8.4</span>
                 </div>
                 <div class="form-group">
-                    <label for="workingDays">Jours par semaine:</label>
+                    <label for="workingDays" data-i18n="popup.workingDaysLabel">Jours par semaine:</label>
                     <select id="workingDays">
                         <option value="5">5 jours</option>
                         <option value="4">4 jours</option>
@@ -34,9 +34,9 @@
             </section>
 
             <section class="config-section">
-                <h2>🌍 Langue</h2>
+                <h2 data-i18n="popup.languageTitle">🌍 Langue</h2>
                 <div class="form-group">
-                    <label for="language">Langue de l'interface:</label>
+                    <label for="language" data-i18n="popup.languageLabel">Langue de l'interface:</label>
                     <select id="language">
                         <option value="fr">🇫🇷 Français</option>
                         <option value="en">🇬🇧 English</option>
@@ -46,34 +46,34 @@
             </section>
 
             <section class="config-section">
-                <h2>🍽️ Configuration des pauses</h2>
+                <h2 data-i18n="popup.pauseTitle">🍽️ Configuration des pauses</h2>
                 <div class="form-row">
                     <div class="form-group">
-                        <label for="lunchStart">Début pause déjeuner:</label>
+                        <label for="lunchStart" data-i18n="popup.lunchStartLabel">Début pause déjeuner:</label>
                         <input type="number" id="lunchStart" min="9" max="15" placeholder="11">
                         <span class="help-text">Heure (format 24h)</span>
                     </div>
                     <div class="form-group">
-                        <label for="lunchEnd">Fin pause déjeuner:</label>
+                        <label for="lunchEnd" data-i18n="popup.lunchEndLabel">Fin pause déjeuner:</label>
                         <input type="number" id="lunchEnd" min="11" max="17" placeholder="14">
                         <span class="help-text">Heure (format 24h)</span>
                     </div>
                 </div>
                 <div class="form-group">
-                    <label for="minPause">Pause minimum (minutes):</label>
+                    <label for="minPause" data-i18n="popup.minPauseLabel">Pause minimum (minutes):</label>
                     <input type="number" id="minPause" min="15" max="120" step="5" placeholder="30">
                 </div>
             </section>
 
             <section class="config-section">
-                <h2>📊 Personnalisation du tableau</h2>
+                <h2 data-i18n="popup.tableTitle">📊 Personnalisation du tableau</h2>
                 <div class="form-group">
-                    <label for="convertRows">Lignes à convertir en jours:</label>
+                    <label for="convertRows" data-i18n="popup.convertRowsLabel">Lignes à convertir en jours:</label>
                     <textarea id="convertRows" rows="3" placeholder="Vacances&#10;Congés payés&#10;Formation"></textarea>
                     <span class="help-text">Une ligne par nom de ligne (sensible à la casse)</span>
                 </div>
                 <div class="form-group">
-                    <label for="removeRows">Lignes à supprimer:</label>
+                    <label for="removeRows" data-i18n="popup.removeRowsLabel">Lignes à supprimer:</label>
                     <textarea id="removeRows" rows="3" placeholder="Ligne inutile&#10;Autre ligne"></textarea>
                     <span class="help-text">Une ligne par nom de ligne (sensible à la casse)</span>
                 </div>
@@ -82,8 +82,8 @@
 
         <footer class="footer">
             <div class="button-group">
-                <button id="resetBtn" class="btn btn-secondary">🔄 Réinitialiser</button>
-                <button id="saveBtn" class="btn btn-primary">💾 Sauvegarder</button>
+                <button id="resetBtn" class="btn btn-secondary" data-i18n="popup.resetButton">🔄 Réinitialiser</button>
+                <button id="saveBtn" class="btn btn-primary" data-i18n="popup.saveButton">💾 Sauvegarder</button>
             </div>
             <div class="status" id="status"></div>
         </footer>

--- a/popup.js
+++ b/popup.js
@@ -22,6 +22,7 @@ class TimeManagerPopup {
     init() {
         this.bindEvents();
         this.loadConfiguration();
+        this.applyTranslations();
     }
 
     bindEvents() {
@@ -32,6 +33,20 @@ class TimeManagerPopup {
         document.getElementById('language')
             .addEventListener('change', (e) => this.onLanguageChange(e));
         this.setupAutoSave();
+    }
+
+    applyTranslations() {
+        document.querySelectorAll('[data-i18n]').forEach(el => {
+            const keys = el.getAttribute('data-i18n').split('.');
+            let txt = this.translations;
+            keys.forEach(k => { if (txt) txt = txt[k]; });
+            if (!txt) return;
+            if (el.tagName === 'TITLE') {
+                document.title = txt;
+            } else {
+                el.textContent = txt;
+            }
+        });
     }
 
     setupAutoSave() {
@@ -50,8 +65,10 @@ class TimeManagerPopup {
     onLanguageChange(event) {
         const select = event.target;
         this.translations = window.TRANSLATIONS[select.value] || this.translations;
+        document.documentElement.lang = select.value;
         select.classList.add('lang-changed');
         setTimeout(() => select.classList.remove('lang-changed'), 1200);
+        this.applyTranslations();
     }
 
     loadConfiguration() {
@@ -64,6 +81,8 @@ class TimeManagerPopup {
                 const cfg = result.timeManagerConfig || this.defaultConfig;
                 this.populateForm(cfg);
                 this.translations = window.TRANSLATIONS[cfg.LANGUAGE] || this.translations;
+                document.documentElement.lang = cfg.LANGUAGE;
+                this.applyTranslations();
                 const loadedMsg = this.translations.configLoaded || 'Configuration chargée';
                 this.showStatus(`⚙️ ${loadedMsg}`, 'info');
             }
@@ -95,6 +114,7 @@ class TimeManagerPopup {
                 this.showStatus('❌ Erreur de sauvegarde', 'error');
             } else {
                 this.translations = window.TRANSLATIONS[config.LANGUAGE] || this.translations;
+                this.applyTranslations();
                 const msg = this.translations.restartNotice || '';
                 const saved = this.translations.configSaved || 'Configuration sauvegardée !';
                 this.showStatus(`✅ ${saved} ${msg}`, 'success');
@@ -149,6 +169,8 @@ class TimeManagerPopup {
             } else {
                 this.populateForm(this.defaultConfig);
                 this.translations = window.TRANSLATIONS[this.defaultConfig.LANGUAGE] || this.translations;
+                document.documentElement.lang = this.defaultConfig.LANGUAGE;
+                this.applyTranslations();
                 const resetMsg = this.translations.configReset || 'Configuration réinitialisée';
                 this.showStatus(`🔄 ${resetMsg}`, 'info');
             }

--- a/translations.js
+++ b/translations.js
@@ -16,7 +16,26 @@ window.TRANSLATIONS = {
         restartNotice: "Veuillez recharger l'onglet pour appliquer la nouvelle langue",
         configSaved: "Configuration sauvegardée !",
         configLoaded: "Configuration chargée",
-        configReset: "Configuration réinitialisée"
+        configReset: "Configuration réinitialisée",
+        popup: {
+            title: "Time Manager - Configuration",
+            subtitle: "Configuration",
+            description: "Personnalisez les paramètres ci-dessous. Les modifications sont sauvegardées automatiquement. Changez la langue pour traduire l'interface puis redémarrez la page.",
+            workHoursTitle: "⏰ Heures de travail",
+            dailyHoursLabel: "Heures par jour:",
+            workingDaysLabel: "Jours par semaine:",
+            languageTitle: "🌍 Langue",
+            languageLabel: "Langue de l'interface:",
+            pauseTitle: "🍽️ Configuration des pauses",
+            lunchStartLabel: "Début pause déjeuner:",
+            lunchEndLabel: "Fin pause déjeuner:",
+            minPauseLabel: "Pause minimum (minutes):",
+            tableTitle: "📊 Personnalisation du tableau",
+            convertRowsLabel: "Lignes à convertir en jours:",
+            removeRowsLabel: "Lignes à supprimer:",
+            resetButton: "🔄 Réinitialiser",
+            saveButton: "💾 Sauvegarder"
+        }
     },
     en: {
         welcome: "Welcome",
@@ -34,7 +53,26 @@ window.TRANSLATIONS = {
         restartNotice: "Please reload the tab to apply the new language",
         configSaved: "Configuration saved!",
         configLoaded: "Configuration loaded",
-        configReset: "Configuration reset"
+        configReset: "Configuration reset",
+        popup: {
+            title: "Time Manager - Settings",
+            subtitle: "Settings",
+            description: "Customize the settings below. Changes are saved automatically. Change the language to translate the interface then reload the page.",
+            workHoursTitle: "⏰ Work Hours",
+            dailyHoursLabel: "Hours per day:",
+            workingDaysLabel: "Days per week:",
+            languageTitle: "🌍 Language",
+            languageLabel: "Interface language:",
+            pauseTitle: "🍽️ Break settings",
+            lunchStartLabel: "Lunch break start:",
+            lunchEndLabel: "Lunch break end:",
+            minPauseLabel: "Minimum break (minutes):",
+            tableTitle: "📊 Table customization",
+            convertRowsLabel: "Rows to convert to days:",
+            removeRowsLabel: "Rows to remove:",
+            resetButton: "🔄 Reset",
+            saveButton: "💾 Save"
+        }
     },
     de: {
         welcome: "Willkommen",
@@ -52,6 +90,25 @@ window.TRANSLATIONS = {
         restartNotice: "Laden Sie den Tab neu, um die neue Sprache anzuwenden",
         configSaved: "Konfiguration gespeichert!",
         configLoaded: "Konfiguration geladen",
-        configReset: "Konfiguration zurückgesetzt"
+        configReset: "Konfiguration zurückgesetzt",
+        popup: {
+            title: "Time Manager - Einstellungen",
+            subtitle: "Einstellungen",
+            description: "Passen Sie unten die Parameter an. Änderungen werden automatisch gespeichert. Sprache ändern um die Oberfläche zu übersetzen und Seite neu laden.",
+            workHoursTitle: "⏰ Arbeitsstunden",
+            dailyHoursLabel: "Stunden pro Tag:",
+            workingDaysLabel: "Tage pro Woche:",
+            languageTitle: "🌍 Sprache",
+            languageLabel: "Sprache der Oberfläche:",
+            pauseTitle: "🍽️ Pauseneinstellungen",
+            lunchStartLabel: "Beginn Mittagspause:",
+            lunchEndLabel: "Ende Mittagspause:",
+            minPauseLabel: "Minimale Pause (Minuten):",
+            tableTitle: "📊 Tabellenanpassung",
+            convertRowsLabel: "Zeilen zu Tagen konvertieren:",
+            removeRowsLabel: "Zeilen entfernen:",
+            resetButton: "🔄 Zurücksetzen",
+            saveButton: "💾 Speichern"
+        }
     }
 };


### PR DESCRIPTION
## Summary
- make popup UI translatable using `data-i18n`
- dynamically apply translations when configuration or language changes
- store new popup strings for French, English and German

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6846c7a69c0c8320b6e31da3214122f3