### PR TITLE
Improve popup translations

### DIFF
--- a/popup.html
+++ b/popup.html
@@ -68,19 +68,19 @@
             <section class="config-section">
                 <h2 data-i18n="popup.tableTitle">📊 Personnalisation du tableau</h2>
                 <div class="form-group">
-                    <label>Lignes à convertir en jours:</label>
+                    <label data-i18n="popup.convertRowsLabel">Lignes à convertir en jours:</label>
                     <ul id="convertRowsList" class="checkbox-list"></ul>
                     <div class="checkbox-add">
-                        <input type="text" id="convertRowsInput" placeholder="Nouvelle ligne">
-                        <button id="addConvertRowBtn" class="btn btn-secondary small-btn">Ajouter</button>
+                        <input type="text" id="convertRowsInput" placeholder="Nouvelle ligne" data-i18n-placeholder="popup.newRowPlaceholder">
+                        <button id="addConvertRowBtn" class="btn btn-secondary small-btn" data-i18n="popup.addButton">Ajouter</button>
                     </div>
                 </div>
                 <div class="form-group">
-                    <label>Lignes à supprimer:</label>
+                    <label data-i18n="popup.removeRowsLabel">Lignes à supprimer:</label>
                     <ul id="removeRowsList" class="checkbox-list"></ul>
                     <div class="checkbox-add">
-                        <input type="text" id="removeRowsInput" placeholder="Nouvelle ligne">
-                        <button id="addRemoveRowBtn" class="btn btn-secondary small-btn">Ajouter</button>
+                        <input type="text" id="removeRowsInput" placeholder="Nouvelle ligne" data-i18n-placeholder="popup.newRowPlaceholder">
+                        <button id="addRemoveRowBtn" class="btn btn-secondary small-btn" data-i18n="popup.addButton">Ajouter</button>
                     </div>
                 </div>
             </section>
@@ -88,9 +88,9 @@
 
         <footer class="footer">
             <div class="button-group">
-                <button id="resetBtn" class="btn btn-secondary">🔄 Réinitialiser</button>
-                <button id="saveBtn" class="btn btn-primary">💾 Sauvegarder</button>
-                <button id="refreshBtn" class="btn btn-secondary">🔃 Rafraîchir</button>
+                <button id="resetBtn" class="btn btn-secondary" data-i18n="popup.resetButton">🔄 Réinitialiser</button>
+                <button id="saveBtn" class="btn btn-primary" data-i18n="popup.saveButton">💾 Sauvegarder</button>
+                <button id="refreshBtn" class="btn btn-secondary" data-i18n="popup.refreshButton">🔃 Rafraîchir</button>
             </div>
             <div class="status" id="status"></div>
         </footer>

--- a/popup.js
+++ b/popup.js
@@ -53,6 +53,13 @@ class TimeManagerPopup {
                 el.textContent = txt;
             }
         });
+
+        document.querySelectorAll('[data-i18n-placeholder]').forEach(el => {
+            const keys = el.getAttribute('data-i18n-placeholder').split('.');
+            let txt = this.translations;
+            keys.forEach(k => { if (txt) txt = txt[k]; });
+            if (txt) el.placeholder = txt;
+        });
     }
 
     setupAutoSave() {
@@ -135,7 +142,8 @@ class TimeManagerPopup {
             if (chrome.runtime.lastError) {
                 console.error(chrome.runtime.lastError);
                 this.populateForm(this.defaultConfig);
-                this.showStatus('❌ Erreur de chargement', 'error');
+                const err = this.translations.loadError || 'Erreur de chargement';
+                this.showStatus(`❌ ${err}`, 'error');
             } else {
                 const cfg = result.timeManagerConfig || this.defaultConfig;
                 this.populateForm(cfg);
@@ -170,7 +178,8 @@ class TimeManagerPopup {
         chrome.storage.sync.set({ timeManagerConfig: config }, () => {
             if (chrome.runtime.lastError) {
                 console.error(chrome.runtime.lastError);
-                this.showStatus('❌ Erreur de sauvegarde', 'error');
+                const err = this.translations.saveError || 'Erreur de sauvegarde';
+                this.showStatus(`❌ ${err}`, 'error');
             } else {
                 this.translations = window.TRANSLATIONS[config.LANGUAGE] || this.translations;
                 this.applyTranslations();
@@ -214,11 +223,13 @@ class TimeManagerPopup {
     }
 
     resetConfiguration() {
-        if (!confirm('Êtes-vous sûr de vouloir réinitialiser la configuration ?')) return;
+        const confirmMsg = this.translations.resetConfirm || 'Êtes-vous sûr de vouloir réinitialiser la configuration ?';
+        if (!confirm(confirmMsg)) return;
         chrome.storage.sync.remove('timeManagerConfig', () => {
             if (chrome.runtime.lastError) {
                 console.error(chrome.runtime.lastError);
-                this.showStatus('❌ Erreur de réinitialisation', 'error');
+                const err = this.translations.resetError || 'Erreur de réinitialisation';
+                this.showStatus(`❌ ${err}`, 'error');
             } else {
                 this.populateForm(this.defaultConfig);
                 this.translations = window.TRANSLATIONS[this.defaultConfig.LANGUAGE] || this.translations;

--- a/translations.js
+++ b/translations.js
@@ -17,6 +17,10 @@ window.TRANSLATIONS = {
         configSaved: "Configuration sauvegardée !",
         configLoaded: "Configuration chargée",
         configReset: "Configuration réinitialisée",
+        saveError: "Erreur de sauvegarde",
+        loadError: "Erreur de chargement",
+        resetError: "Erreur de réinitialisation",
+        resetConfirm: "Êtes-vous sûr de vouloir réinitialiser la configuration ?",
         popup: {
             title: "Time Manager - Configuration",
             subtitle: "Configuration",
@@ -34,7 +38,10 @@ window.TRANSLATIONS = {
             convertRowsLabel: "Lignes à convertir en jours:",
             removeRowsLabel: "Lignes à supprimer:",
             resetButton: "🔄 Réinitialiser",
-            saveButton: "💾 Sauvegarder"
+            saveButton: "💾 Sauvegarder",
+            refreshButton: "🔃 Rafraîchir",
+            addButton: "Ajouter",
+            newRowPlaceholder: "Nouvelle ligne"
         }
     },
     en: {
@@ -54,6 +61,10 @@ window.TRANSLATIONS = {
         configSaved: "Configuration saved!",
         configLoaded: "Configuration loaded",
         configReset: "Configuration reset",
+        saveError: "Save error",
+        loadError: "Load error",
+        resetError: "Reset error",
+        resetConfirm: "Are you sure you want to reset the configuration?",
         popup: {
             title: "Time Manager - Settings",
             subtitle: "Settings",
@@ -71,7 +82,10 @@ window.TRANSLATIONS = {
             convertRowsLabel: "Rows to convert to days:",
             removeRowsLabel: "Rows to remove:",
             resetButton: "🔄 Reset",
-            saveButton: "💾 Save"
+            saveButton: "💾 Save",
+            refreshButton: "🔃 Refresh",
+            addButton: "Add",
+            newRowPlaceholder: "New row"
         }
     },
     de: {
@@ -91,6 +105,10 @@ window.TRANSLATIONS = {
         configSaved: "Konfiguration gespeichert!",
         configLoaded: "Konfiguration geladen",
         configReset: "Konfiguration zurückgesetzt",
+        saveError: "Fehler beim Speichern",
+        loadError: "Fehler beim Laden",
+        resetError: "Fehler beim Zurücksetzen",
+        resetConfirm: "Möchten Sie die Konfiguration wirklich zurücksetzen?",
         popup: {
             title: "Time Manager - Einstellungen",
             subtitle: "Einstellungen",
@@ -108,7 +126,10 @@ window.TRANSLATIONS = {
             convertRowsLabel: "Zeilen zu Tagen konvertieren:",
             removeRowsLabel: "Zeilen entfernen:",
             resetButton: "🔄 Zurücksetzen",
-            saveButton: "💾 Speichern"
+            saveButton: "💾 Speichern",
+            refreshButton: "🔃 Aktualisieren",
+            addButton: "Hinzufügen",
+            newRowPlaceholder: "Neue Zeile"
         }
     }
 };


### PR DESCRIPTION
## Summary
- localize popup buttons and placeholders
- update translations for FR, EN, and DE
- translate error messages and confirmation prompts in popup.js
- support placeholder translation in popup script

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6846ce058cbc832099d920d3f68bb9b8